### PR TITLE
Fix: Broken links on readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@ Home for general best practices & developer workflow documentation. Any and all 
 
 ## Sections
 
-1. [Agile methodology for developers](/las-docs/agile#readme): Documentation on the agile process
-2. [Git](/las-docs/git#readme): Git usage and practices
-3. [Standardization](/las-docs/standardization#readme): Standards for software development
-4. [Style Guide](/las-docs/style-guide#readme): Style guide for coding, documentation, etc.
+1. [Agile methodology for developers](agile/readme): Documentation on the agile process
+2. [Git](git/readme): Git usage and practices
+3. [Style Guide](style-guide/readme): Style guide for coding, documentation, etc.
 
 ## Contributing Guidelines
 

--- a/agile/README.md
+++ b/agile/README.md
@@ -1,6 +1,6 @@
 # Agile Developer Documentation
 
-1. [Frequently Asked Questions](/las-docs/agile/faq): Answers to the most commom agile questions asked by developers
-2. [Product Backlog](/las-docs/agile/product-backlog): Product backlog refinement and best practices
-3. [Scrum Ceremonies](/las-docs/agile/scrum-ceremonies): Scrum ceremonies on every sprint
-4. [Scrum Roles](/las-docs/agile/scrum-roles): Responsibilities and key attributes for each scrum role
+1. [Frequently Asked Questions](faq): Answers to the most commom agile questions asked by developers
+2. [Product Backlog](product-backlog): Product backlog refinement and best practices
+3. [Scrum Ceremonies](scrum-ceremonies): Scrum ceremonies on every sprint
+4. [Scrum Roles](scrum-roles): Responsibilities and key attributes for each scrum role

--- a/git/README.md
+++ b/git/README.md
@@ -6,8 +6,8 @@ Documentation about git usage, workflows, naming conventions, etc.
 <!-- omit in toc -->
 # Contents
 
-1. ⭐[Readme Template](/las-docs/git/readme-template): Template for readme files
-2. ⭐[Commit Guidelines](/las-docs/git/commit-guidelines): Writing commits and getting past the linter
-3. [Branching](/las-docs/git/branching): Writing and organizing branches
-4. [Git Usage](/las-docs/git/git-usage): Common git commands and how to use them 
-5. [Pull Requests](/las-docs/git/pull-requests): Creating, naming, and labeling pull requests
+1. ⭐[Readme Template](readme-template): Template for readme files
+2. ⭐[Commit Guidelines](commit-guidelines): Writing commits and getting past the linter
+3. [Branching](branching): Writing and organizing branches
+4. [Git Usage](git-usage): Common git commands and how to use them 
+5. [Pull Requests](pull-requests): Creating, naming, and labeling pull requests

--- a/style-guide/README.md
+++ b/style-guide/README.md
@@ -4,4 +4,4 @@
 This guide will help to ensure the development follow at least some standards in order to keep the code more readble and documented to be improved accross different teams. 
 
 
-1. [Documenting Your Code](/las-docs/style-guide/documenting-your-code): Docblocks
+1. [Documenting Your Code](documenting-your-code): Docblocks


### PR DESCRIPTION
Changes made according by [Github Docs](https://docs.github.com/pt/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-readmes#relative-links-and-image-paths-in-readme-files)